### PR TITLE
feat: `SLOAD` optimized route and price

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/amm-core"]
 	path = lib/amm-core
 	url = https://github.com/reservoir-labs/amm-core
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/Vectorized/solady

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc = "0.8.23"
-#via_ir = true
+via_ir = true
 bytecode_hash = "ipfs"
 optimizer_runs = 1_000_000
 libs = ['lib']

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -147,8 +147,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
     /// for priceCache[aTokenA][aTokenB] but instead the prices of its constituent simple routes will be written.
     /// @param aTokenA Address of one of the tokens for the price update. Does not have to be less than address of aTokenB
     /// @param aTokenB Address of one of the tokens for the price update. Does not have to be greater than address of aTokenA
-    /// @param aRewardRecipient The beneficiary of the reward. Must implement the receive function if is a smart
-    /// contract address. Set to address(0) if not seeking a reward
+    /// @param aRewardRecipient The beneficiary of the reward. Must be able to receive ether. Set to address(0) if not seeking a reward
     function updatePrice(address aTokenA, address aTokenB, address aRewardRecipient) public nonReentrant {
         (address lToken0, address lToken1) = aTokenA.sortTokens(aTokenB);
 

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -352,10 +352,10 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
     function _checkAndPopulateIntermediateRoute(address aToken0, address aToken1) internal {
         (address lLowerToken, address lHigherToken) = aToken0.sortTokens(aToken1);
 
-        bytes32 lIntermediateRouteSlot = lLowerToken.calculateSlot(lHigherToken);
+        bytes32 lSlot = lLowerToken.calculateSlot(lHigherToken);
         bytes32 lData;
         assembly {
-            lData := sload(lIntermediateRouteSlot)
+            lData := sload(lSlot)
         }
         if (lData == bytes32(0)) {
             address[] memory lIntermediateRoute = new address[](2);
@@ -450,7 +450,6 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
     }
 
     // sets a specific pair to serve as price feed for a certain route
-    // TODO: actually is it necessary to have so many args? Maybe all we need is whitelistPair(ReservoirPair)
     function designatePair(address aToken0, address aToken1, ReservoirPair aPair) external nonReentrant onlyOwner {
         (aToken0, aToken1) = aToken0.sortTokens(aToken1);
         assert(aToken0 == address(aPair.token0()) && aToken1 == address(aPair.token1()));
@@ -519,6 +518,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
 
         bytes32 lSlot = aToken0.calculateSlot(aToken1);
 
+        // clear all storage slots that the route has written to previously
         for (uint256 i = 0; i < lRoute.length - 1; ++i) {
             assembly {
                 sstore(add(lSlot, i), 0)

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -407,7 +407,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
         if (lRoute.length == 0) {
             revert PO_NoPath();
         }
-        // if composite route, read simple prices to derive composite price
+        // for composite route, read simple prices to derive composite price
         else if (lRoute.length > 2) {
             lPrice = WAD;
             for (uint256 i = 0; i < lRoute.length - 1; ++i) {
@@ -417,7 +417,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 // meaning, each segment of the route represents a real price between pair, and not the result of composite routing
                 // therefore we do not check `_route` again to ensure that there is indeed a route
                 (uint256 lRoutePrice, int256 lRouteDecimalDiff) = _priceCache(lLowerToken, lHigherToken);
-                lDecimalDiff += lRouteDecimalDiff;
+                lDecimalDiff += lRouteDecimalDiff; // will not over/underflow given that each value is between -18 and +18 and that the final value will also be within this range
                 lPrice = lPrice * (lLowerToken == lRoute[i] ? lRoutePrice : lRoutePrice.invertWad()) / WAD;
             }
         }

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -492,7 +492,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
         // composite route
         else {
             uint256 lIndex;
-            // populate first + intermediate hops
+            // populate all intermediate hops
             for (uint256 i = 1; i < lRouteLength; ++i) {
                 address lNextToken = aRoute[i];
 

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -390,13 +390,13 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 }
 
                 (address lLowerToken, address lHigherToken) = aRoute[i - 1].sortTokens(aRoute[i]);
-                bytes32 lIntermediateRoutelSlot = _calculateSlot(lLowerToken, lHigherToken);
+                bytes32 lIntermediateRouteSlot = _calculateSlot(lLowerToken, lHigherToken);
                 bytes32 lRead;
                 assembly {
-                    lRead := sload(lIntermediateRoutelSlot)
+                    lRead := sload(lIntermediateRouteSlot)
                 }
                 if (lRead == bytes32(0)) {
-                    address[] memory lIntermediateRoute;
+                    address[] memory lIntermediateRoute = new address[](2);
                     lIntermediateRoute[0] = lLowerToken;
                     lIntermediateRoute[1] = lHigherToken;
                     setRoute(lLowerToken, lHigherToken, lIntermediateRoute);
@@ -410,6 +410,18 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 lLastToken := shl(88, lLastToken)
                 data := or(data, lLastToken)
                 sstore(add(lSlot, lIndex), data)
+            }
+            (address lLowerToken, address lHigherToken) = aRoute[aRoute.length - 2].sortTokens(aRoute[aRoute.length - 1]);
+            bytes32 lIntermediateRouteSlot = _calculateSlot(lLowerToken, lHigherToken);
+            bytes32 lRead;
+            assembly {
+                lRead := sload(lIntermediateRouteSlot)
+            }
+            if (lRead == bytes32(0)) {
+                address[] memory lIntermediateRoute = new address[](2);
+                lIntermediateRoute[0] = lLowerToken;
+                lIntermediateRoute[1] = lHigherToken;
+                setRoute(lLowerToken, lHigherToken, lIntermediateRoute);
             }
         }
         emit Route(aToken0, aToken1, aRoute);

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -425,5 +425,6 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
         assembly {
             sstore(lSlot, 0)
         }
+        emit Route(aToken0, aToken1, new address[](0));
     }
 }

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -417,7 +417,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 // meaning, each segment of the route represents a real price between pair, and not the result of composite routing
                 // therefore we do not check `_route` again to ensure that there is indeed a route
                 (uint256 lRoutePrice, int256 lRouteDecimalDiff) = _priceCache(lLowerToken, lHigherToken);
-                lDecimalDiff += (lLowerToken == lRoute[i]) ?  lRouteDecimalDiff : -lRouteDecimalDiff; // will not over/underflow given that each value is between -18 and +18 and that the final value will also be within this range
+                lDecimalDiff += (lLowerToken == lRoute[i]) ? lRouteDecimalDiff : -lRouteDecimalDiff; // will not over/underflow given that each value is between -18 and +18 and that the final value will also be within this range
                 lPrice = lPrice * (lLowerToken == lRoute[i] ? lRoutePrice : lRoutePrice.invertWad()) / WAD;
             }
         }

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -320,7 +320,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
         // composite route
         else if (lFlag == FLAG_COMPOSITE_NEXT) {
             address[] memory lIntermediatePrices = new address[](MAX_ROUTE_LENGTH - 1);
-            address lToken = address(uint160(uint256(lData >> 88)));
+            address lToken = address(uint160(uint256(lData)));
             lResults[0] = aToken0;
             lResults[1] = lToken;
             lRouteLength = 2;
@@ -328,7 +328,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 assembly {
                     lData := sload(add(lSlot, sub(lRouteLength, 1)))
                 }
-                lToken = address(uint160(uint256(lData >> 88)));
+                lToken = address(uint160(uint256(lData)));
                 lResults[lRouteLength] = lToken;
                 lRouteLength += 1;
 
@@ -477,7 +477,6 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 address lNextToken = aRoute[i];
                 assembly {
                     let data := shl(248, 0x02) // 0x02 in the uppermost byte
-                    lNextToken := shl(88, lNextToken)
                     data := or(data, lNextToken)
                     sstore(add(lSlot, lIndex), data) // need to do funny things with index?
                     lIndex := add(lIndex, 1)
@@ -501,7 +500,6 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
             address lLastToken = aRoute[aRoute.length - 1];
             assembly {
                 let data := shl(248, 0x03) // 0x03 in the uppermost byte
-                lLastToken := shl(88, lLastToken)
                 data := or(data, lLastToken)
                 sstore(add(lSlot, lIndex), data)
             }

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -17,7 +17,6 @@ import { Utils } from "src/libraries/Utils.sol";
 import { Owned } from "lib/amm-core/lib/solmate/src/auth/Owned.sol";
 import { ReentrancyGuard } from "lib/amm-core/lib/solmate/src/utils/ReentrancyGuard.sol";
 import { FixedPointMathLib } from "lib/amm-core/lib/solady/src/utils/FixedPointMathLib.sol";
-import { Bytes32Lib } from "amm-core/libraries/Bytes32.sol";
 import { FlagsLib } from "src/libraries/FlagsLib.sol";
 
 contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.sender), ReentrancyGuard {

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -451,9 +451,6 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
     /// @param aToken0 Address of the lower token
     /// @param aToken1 Address of the higher token
     /// @param aRoute Path with which the price between aToken0 and aToken1 should be derived
-    // should we make this recursive, meaning for a route A-B-C-D
-    // besides defining A-D, A-B, B-C, and C-D, we also define
-    // A-B-C, B-C-D ?
     function setRoute(address aToken0, address aToken1, address[] memory aRoute) public onlyOwner {
         if (aToken0 == aToken1) revert RPC_SAME_TOKEN();
         if (aToken1 < aToken0) revert RPC_TOKENS_UNSORTED();

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -417,7 +417,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
                 // meaning, each segment of the route represents a real price between pair, and not the result of composite routing
                 // therefore we do not check `_route` again to ensure that there is indeed a route
                 (uint256 lRoutePrice, int256 lRouteDecimalDiff) = _priceCache(lLowerToken, lHigherToken);
-                lDecimalDiff += lRouteDecimalDiff; // will not over/underflow given that each value is between -18 and +18 and that the final value will also be within this range
+                lDecimalDiff += (lLowerToken == lRoute[i]) ?  lRouteDecimalDiff : -lRouteDecimalDiff; // will not over/underflow given that each value is between -18 and +18 and that the final value will also be within this range
                 lPrice = lPrice * (lLowerToken == lRoute[i] ? lRoutePrice : lRoutePrice.invertWad()) / WAD;
             }
         }

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -482,7 +482,9 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
         // simple route
         if (lRouteLength == 2) {
             assembly {
-                let data := shl(248, 0x01) // 0x01 in the uppermost byte
+                // Set the uppermost byte of data to FLAG_SIMPLE_PRICE.
+                let data := shl(248, 0x01)
+                // Write data to storage.
                 sstore(lSlot, data)
             }
             // update price for simple routes
@@ -494,7 +496,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
             for (uint256 i = 1; i < lRouteLength; ++i) {
                 address lNextToken = aRoute[i];
 
-                // Set the uppermost byte of data to FLAG_COMPOSITE_NEXT for intermediate hops or FLAG_COMPOSITE_END for the last hop.
+                // Set the uppermost byte of lData to FLAG_COMPOSITE_NEXT for intermediate hops or FLAG_COMPOSITE_END for the last hop.
                 bytes32 lData = (i == lRouteLength - 1 ? FLAG_COMPOSITE_END : FLAG_COMPOSITE_NEXT) << 248;
                 assembly {
                     // Combine the flag and the next token's address.

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -19,8 +19,6 @@ import { ReentrancyGuard } from "lib/amm-core/lib/solmate/src/utils/ReentrancyGu
 import { FixedPointMathLib } from "lib/amm-core/lib/solady/src/utils/FixedPointMathLib.sol";
 import { Bytes32Lib } from "amm-core/libraries/Bytes32.sol";
 
-import { console2 } from "forge-std/console2.sol";
-
 bytes32 constant FLAG_UNINITIALIZED = bytes32(uint256(0x00));
 bytes32 constant FLAG_SIMPLE_PRICE = bytes32(uint256(0x01));
 bytes32 constant FLAG_COMPOSITE_NEXT = bytes32(uint256(0x02));

--- a/src/ReservoirPriceOracle.sol
+++ b/src/ReservoirPriceOracle.sol
@@ -57,6 +57,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
     error RPC_INVALID_ROUTE();
     error RPC_WRITE_TO_NON_SIMPLE_ROUTE();
     error RPC_UNSUPPORTED_TOKEN_DECIMALS();
+    error RPC_PRICE_ZER0();
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     //                                        STORAGE                                            //
@@ -422,6 +423,7 @@ contract ReservoirPriceOracle is IPriceOracle, IReservoirPriceOracle, Owned(msg.
             }
         }
 
+        if (lPrice == 0) revert RPC_PRICE_ZER0();
         lPrice = lToken0 == aBase ? lPrice : lPrice.invertWad();
         lDecimalDiff = lToken0 == aBase ? lDecimalDiff : -lDecimalDiff;
 

--- a/src/libraries/FlagsLib.sol
+++ b/src/libraries/FlagsLib.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Bytes32Lib } from "amm-core/libraries/Bytes32.sol";
+
+type Flag is bytes1;
+//type Data is bytes32;
+
+library FlagsLib {
+    using Bytes32Lib for bytes32;
+
+    error DECIMAL_DIFF_OUT_OF_RANGE();
+
+    bytes32 public constant FLAG_UNINITIALIZED = bytes32(uint256(0x0));
+    bytes32 public constant FLAG_SIMPLE_PRICE = bytes32(uint256(0x1));
+    bytes32 public constant FLAG_COMPOSITE_NEXT = bytes32(uint256(0x2));
+    bytes32 public constant FLAG_COMPOSITE_END = bytes32(uint256(0x3));
+
+    function getRouteFlag(bytes32 aData) internal pure returns (bytes32) {
+        return aData >> 254;
+    }
+
+    function isSimplePrice(bytes32 aData) internal pure returns (bool) {
+        return getRouteFlag(aData) == FLAG_SIMPLE_PRICE;
+    }
+
+    // Positive value indicates that token1 has a greater number of decimals compared to token2
+    // while a negative value indicates otherwise.
+    // range of values between -18 and 18
+    function getDecimalDifference(bytes32 aData) internal pure returns (int256) {
+        bytes1 lFirstByte = aData[0];
+        bytes1 lRawData = lFirstByte & 0x3f; // mask out the route flag
+
+        // negative number
+        if (lRawData & bytes1(0x20) != bytes1(0)) {
+            bytes1 lAbs = lRawData & 0x1f;
+            return -int256(uint256(bytes32(lAbs) >> 248));
+        }
+        // positive number
+        else {
+            return int256(uint256(bytes32(lRawData) >> 248));
+        }
+    }
+
+    // Packs the decimal difference into a 6 bit space from bits 3-8, with the leftmost bit used to indicate the sign
+    // Assumes that aDecimalDifference is between -18 and 18
+    function packDecimalDifference(int256 aDecimalDifference) internal pure returns (bytes32 rPacked) {
+        if (aDecimalDifference < -18 || aDecimalDifference > 18) revert DECIMAL_DIFF_OUT_OF_RANGE();
+
+        bytes32 lSignBit;
+        if (aDecimalDifference < 0) {
+            lSignBit = bytes1(0x20); // 0b00100000
+            aDecimalDifference = ~aDecimalDifference + 1;
+        }
+        rPacked = lSignBit | bytes32(uint256(aDecimalDifference)) << 248;
+    }
+
+    function combine(bytes32 aFlag, int256 aDecimalDifference) internal pure returns (bytes32 rCombined) {
+        bytes32 lPackedDecimalDiff = packDecimalDifference(aDecimalDifference);
+        rCombined = aFlag << 254 | lPackedDecimalDiff;
+    }
+
+    function getPrice(bytes32 aData) internal pure returns (uint256 rPrice) {
+        rPrice = (aData & 0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff).toUint256();
+    }
+}

--- a/src/libraries/FlagsLib.sol
+++ b/src/libraries/FlagsLib.sol
@@ -1,14 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import { Bytes32Lib } from "amm-core/libraries/Bytes32.sol";
-
-type Flag is bytes1;
-//type Data is bytes32;
-
 library FlagsLib {
-    using Bytes32Lib for *;
-
     error DECIMAL_DIFF_OUT_OF_RANGE();
 
     bytes32 public constant FLAG_UNINITIALIZED = bytes32(uint256(0x0));
@@ -18,6 +11,10 @@ library FlagsLib {
 
     function getRouteFlag(bytes32 aData) internal pure returns (bytes32) {
         return aData >> 248;
+    }
+
+    function getSecondRouteFlag(bytes32 aData) internal pure returns (bytes32) {
+        return aData >> 80 & 0x00000000000000000000000000000000000000000000000000000000000000ff;
     }
 
     function isSimplePrice(bytes32 aData) internal pure returns (bool) {
@@ -38,6 +35,23 @@ library FlagsLib {
     }
 
     function getPrice(bytes32 aData) internal pure returns (uint256 rPrice) {
-        rPrice = (aData & 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff).toUint256();
+        rPrice = uint256(aData & 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
+    }
+
+    function getTokenFirstWord(bytes32 aData) internal pure returns (address rToken) {
+        rToken =
+            address(uint160(uint256(aData & 0x00ffffffffffffffffffffffffffffffffffffffff0000000000000000000000) >> 88));
+    }
+
+    function getThirdToken(bytes32 aFirstWord, bytes32 aSecondWord) internal pure returns (address rToken) {
+        bytes32 lFirst10Bytes = (aFirstWord & 0x00000000000000000000000000000000000000000000ffffffffffffffffffff) << 80;
+        bytes32 lLast10Bytes = aSecondWord >> 176;
+        rToken = address(uint160(uint256(lFirst10Bytes | lLast10Bytes)));
+    }
+
+    function getFourthToken(bytes32 aSecondWord) internal pure returns (address rToken) {
+        rToken = address(
+            uint160(uint256(aSecondWord & 0x0000000000000000000000ffffffffffffffffffffffffffffffffffffffff00) >> 8)
+        );
     }
 }

--- a/src/libraries/FlagsLib.sol
+++ b/src/libraries/FlagsLib.sol
@@ -7,7 +7,7 @@ type Flag is bytes1;
 //type Data is bytes32;
 
 library FlagsLib {
-    using Bytes32Lib for bytes32;
+    using Bytes32Lib for *;
 
     error DECIMAL_DIFF_OUT_OF_RANGE();
 
@@ -17,7 +17,7 @@ library FlagsLib {
     bytes32 public constant FLAG_COMPOSITE_END = bytes32(uint256(0x3));
 
     function getRouteFlag(bytes32 aData) internal pure returns (bytes32) {
-        return aData >> 254;
+        return aData >> 248;
     }
 
     function isSimplePrice(bytes32 aData) internal pure returns (bool) {
@@ -27,40 +27,17 @@ library FlagsLib {
     // Positive value indicates that token1 has a greater number of decimals compared to token2
     // while a negative value indicates otherwise.
     // range of values between -18 and 18
-    function getDecimalDifference(bytes32 aData) internal pure returns (int256) {
-        bytes1 lFirstByte = aData[0];
-        bytes1 lRawData = lFirstByte & 0x3f; // mask out the route flag
-
-        // negative number
-        if (lRawData & bytes1(0x20) != bytes1(0)) {
-            bytes1 lAbs = lRawData & 0x1f;
-            return -int256(uint256(bytes32(lAbs) >> 248));
-        }
-        // positive number
-        else {
-            return int256(uint256(bytes32(lRawData) >> 248));
-        }
+    function getDecimalDifference(bytes32 aData) internal pure returns (int256 rDiff) {
+        rDiff = int8(uint8(aData[1]));
     }
 
-    // Packs the decimal difference into a 6 bit space from bits 3-8, with the leftmost bit used to indicate the sign
     // Assumes that aDecimalDifference is between -18 and 18
-    function packDecimalDifference(int256 aDecimalDifference) internal pure returns (bytes32 rPacked) {
-        if (aDecimalDifference < -18 || aDecimalDifference > 18) revert DECIMAL_DIFF_OUT_OF_RANGE();
-
-        bytes32 lSignBit;
-        if (aDecimalDifference < 0) {
-            lSignBit = bytes1(0x20); // 0b00100000
-            aDecimalDifference = ~aDecimalDifference + 1;
-        }
-        rPacked = lSignBit | bytes32(uint256(aDecimalDifference)) << 248;
-    }
-
     function combine(bytes32 aFlag, int256 aDecimalDifference) internal pure returns (bytes32 rCombined) {
-        bytes32 lPackedDecimalDiff = packDecimalDifference(aDecimalDifference);
-        rCombined = aFlag << 254 | lPackedDecimalDiff;
+        bytes32 lDecimalDifferenceRaw = bytes1(uint8(int8(aDecimalDifference)));
+        rCombined = aFlag << 248 | lDecimalDifferenceRaw >> 8;
     }
 
     function getPrice(bytes32 aData) internal pure returns (uint256 rPrice) {
-        rPrice = (aData & 0x00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff).toUint256();
+        rPrice = (aData & 0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff).toUint256();
     }
 }

--- a/src/libraries/Utils.sol
+++ b/src/libraries/Utils.sol
@@ -12,6 +12,11 @@ library Utils {
         return tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
     }
 
+    /// @dev aToken0 has to be strictly less than aToken1
+    function calculateSlot(address aToken0, address aToken1) internal pure returns (bytes32) {
+        return keccak256(abi.encode(aToken0, aToken1));
+    }
+
     function invertWad(uint256 x) internal pure returns (uint256) {
         if (x > WAD_SQUARED || x == 0) revert PriceOutOfRange();
 

--- a/src/libraries/Utils.sol
+++ b/src/libraries/Utils.sol
@@ -5,7 +5,7 @@ library Utils {
     /// @dev Square of 1e18 (WAD)
     uint256 internal constant WAD_SQUARED = 1e36;
 
-    error PriceOutOfRange();
+    error PriceOutOfRange(uint256 aPrice);
 
     // returns the lower address followed by the higher address
     function sortTokens(address tokenA, address tokenB) internal pure returns (address, address) {
@@ -18,7 +18,7 @@ library Utils {
     }
 
     function invertWad(uint256 x) internal pure returns (uint256) {
-        if (x > WAD_SQUARED || x == 0) revert PriceOutOfRange();
+        if (x > WAD_SQUARED || x == 0) revert PriceOutOfRange(x);
 
         return WAD_SQUARED / x;
     }

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -30,7 +30,7 @@ contract ReservoirPriceOracleTest is BaseTest {
     // writes the cached prices, for easy testing
     function _writePriceCache(address aToken0, address aToken1, uint256 aPrice) internal {
         require(aToken0 < aToken1, "tokens unsorted");
-        require(bytes32(aPrice) & bytes1(0xff) == 0, "PRICE WILL OVERLAP FLAG");
+        require(bytes32(aPrice) & bytes2(0xffff) == 0, "PRICE WILL OVERLAP FLAG");
 
         vm.record();
         _oracle.priceCache(aToken0, aToken1);

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -15,10 +15,12 @@ import {
     IPriceOracle,
     FlagsLib
 } from "src/ReservoirPriceOracle.sol";
+import { Bytes32Lib } from "amm-core/libraries/Bytes32.sol";
 
 contract ReservoirPriceOracleTest is BaseTest {
     using Utils for *;
     using FlagsLib for bytes32;
+    using Bytes32Lib for *;
 
     event DesignatePair(address token0, address token1, ReservoirPair pair);
     event Oracle(address newOracle);
@@ -28,7 +30,7 @@ contract ReservoirPriceOracleTest is BaseTest {
     // writes the cached prices, for easy testing
     function _writePriceCache(address aToken0, address aToken1, uint256 aPrice) internal {
         require(aToken0 < aToken1, "tokens unsorted");
-        require(bytes32(aPrice) & (FlagsLib.FLAG_SIMPLE_PRICE << 254) == 0, "PRICE WILL OVERLAP FLAG");
+        require(bytes32(aPrice) & bytes1(0xff) == 0, "PRICE WILL OVERLAP FLAG");
 
         vm.record();
         _oracle.priceCache(aToken0, aToken1);

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -425,14 +425,14 @@ contract ReservoirPriceOracleTest is BaseTest {
 
         // act
         vm.expectEmit(false, false, false, true);
-        emit Route(lStart, lEnd, lRoute);
-        vm.expectEmit(false, false, false, true);
         emit Route(lStart, lIntermediate1, lIntermediateRoute1);
         vm.expectEmit(true, true, true, true);
         // note the reverse seq here as well
         emit Route(lIntermediate2, lIntermediate1, lIntermediateRoute2);
         vm.expectEmit(false, false, false, true);
         emit Route(lIntermediate2, lEnd, lIntermediateRoute3);
+        vm.expectEmit(false, false, false, true);
+        emit Route(lStart, lEnd, lRoute);
         _oracle.setRoute(lStart, lEnd, lRoute);
 
         // assert

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -478,12 +478,12 @@ contract ReservoirPriceOracleTest is BaseTest {
 
         // act
         vm.expectEmit(false, false, false, true);
+        emit Route(lIntermediate2, lEnd, lIntermediateRoute3);
+        vm.expectEmit(false, false, false, true);
         emit Route(lStart, lIntermediate1, lIntermediateRoute1);
         vm.expectEmit(true, true, true, true);
         // note the reverse seq here as well
         emit Route(lIntermediate2, lIntermediate1, lIntermediateRoute2);
-        vm.expectEmit(false, false, false, true);
-        emit Route(lIntermediate2, lEnd, lIntermediateRoute3);
         vm.expectEmit(false, false, false, true);
         emit Route(lStart, lEnd, lRoute);
         _oracle.setRoute(lStart, lEnd, lRoute);
@@ -531,8 +531,7 @@ contract ReservoirPriceOracleTest is BaseTest {
         assertEq(lQueriedRoute, lRoute);
         bytes32 lSlot1 = address(_tokenA).calculateSlot(address(_tokenD));
         bytes32 lSlot2 = bytes32(uint256(lSlot1) + 1);
-        bytes32 lSlot3 = bytes32(uint256(lSlot2) + 1);
-        bytes32 lData = vm.load(address(_oracle), lSlot3);
+        bytes32 lData = vm.load(address(_oracle), lSlot2);
         assertNotEq(lData, 0);
 
         // act
@@ -559,8 +558,6 @@ contract ReservoirPriceOracleTest is BaseTest {
         lData = vm.load(address(_oracle), lSlot1);
         assertEq(lData, 0);
         lData = vm.load(address(_oracle), lSlot2);
-        assertEq(lData, 0);
-        lData = vm.load(address(_oracle), lSlot3);
         assertEq(lData, 0);
     }
 
@@ -831,23 +828,5 @@ contract ReservoirPriceOracleTest is BaseTest {
         // act & assert
         vm.expectRevert(IPriceOracle.PO_NoPath.selector);
         _oracle.getQuote(123, address(123), address(456));
-    }
-
-    function testXX() external {
-        //        bytes32 FLAG_SIMPLE_PRICE = bytes32(uint256(0x3));
-        //
-        //        console2.logBytes32(FLAG_SIMPLE_PRICE << 254);
-
-        int256 x = -5;
-
-        console2.logBytes32(bytes32(uint256(~x + 1)));
-
-        console2.logInt((x & 0x8000000));
-
-        console2.log(type(int256).min);
-        console2.log(type(int256).max);
-        console2.logBytes32(hex"0010");
-
-        uint256 a = 5;
     }
 }

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -418,14 +418,10 @@ contract ReservoirPriceOracleTest is BaseTest {
         uint256 lPriceStartEnd = (lRoute[0] < lRoute[1] ? lPrice1 : lPrice1.invertWad())
             * (lRoute[1] < lRoute[2] ? lPrice2 : lPrice2.invertWad()) / WAD
             * (lRoute[2] < lRoute[3] ? lPrice3 : lPrice3.invertWad()) / WAD;
-
-        // TODO: the difference is due to the way the arithmetic is done, whether it is inverted first
-        // and which price is multiplied first
-        assertApproxEqRel(
+        assertEq(
             lAmtDOut,
             lAmtIn * (lRoute[0] == address(lTokenA) ? lPriceStartEnd : lPriceStartEnd.invertWad())
-                * (10 ** lTokenDDecimal) / WAD,
-            0.005e18
+                * (10 ** lTokenDDecimal) / WAD
         );
     }
 

--- a/test/unit/ReservoirPriceOracle.t.sol
+++ b/test/unit/ReservoirPriceOracle.t.sol
@@ -127,7 +127,7 @@ contract ReservoirPriceOracleTest is BaseTest {
         );
     }
 
-    function testGetQuote_MultipleHops() external {
+    function testGetQuote_MultipleHops() public {
         // assume
         uint256 lPriceAB = 1e18;
         uint256 lPriceBC = 2e18;
@@ -828,5 +828,21 @@ contract ReservoirPriceOracleTest is BaseTest {
         // act & assert
         vm.expectRevert(IPriceOracle.PO_NoPath.selector);
         _oracle.getQuote(123, address(123), address(456));
+    }
+
+    function testGetQuote_PriceZero() external {
+        // act & assert
+        vm.expectRevert(ReservoirPriceOracle.RPC_PRICE_ZER0.selector);
+        _oracle.getQuote(32111, address(_tokenA), address(_tokenB));
+    }
+
+    function testGetQuote_MultipleHops_PriceZero() external {
+        // arrange
+        testGetQuote_MultipleHops();
+        _writePriceCache(address(_tokenB), address(_tokenC), 0);
+
+        // act & assert
+        vm.expectRevert(ReservoirPriceOracle.RPC_PRICE_ZER0.selector);
+        _oracle.getQuote(321321, address(_tokenA), address(_tokenD));
     }
 }

--- a/test/unit/libraries/FlagsLib.t.sol
+++ b/test/unit/libraries/FlagsLib.t.sol
@@ -10,32 +10,23 @@ contract FlagsLibTest is Test {
     using FlagsLib for int256;
 
     function testGetDecimalDifference() external {
-        bytes32 lPositive = hex"1f";
-        bytes32 lNegative = hex"3f";
-
-        assertEq(lPositive.getDecimalDifference(), 31);
-        assertEq(lNegative.getDecimalDifference(), -31);
-    }
-
-    function testPackDecimalDifference(int256 aDiff) external {
         // arrange
-        int256 lDiff = bound(aDiff, -18, 18);
-
-        // act
-        bytes32 lPacked = lDiff.packDecimalDifference();
-
-        // assert
-        assertEq(lDiff, lPacked.getDecimalDifference());
-    }
-
-    function testPackDecimalDifference_BeyondRange() external {
-        // arrange
-        int256 lDiff = -20;
+        bytes32 lPositive = hex"0012";
+        bytes32 lNegative = hex"00ee";
+        bytes32 lZero = hex"0000";
 
         // act & assert
-        vm.expectRevert(FlagsLib.DECIMAL_DIFF_OUT_OF_RANGE.selector);
-        lDiff.packDecimalDifference();
+        assertEq(lPositive.getDecimalDifference(), 18);
+        assertEq(lNegative.getDecimalDifference(), -18);
+        assertEq(lZero.getDecimalDifference(), 0);
     }
 
-    function testCombine() external { }
+    function testCombine(int8 aDiff) external {
+        // act
+        bytes32 lResult = FlagsLib.FLAG_SIMPLE_PRICE.combine(aDiff);
+
+        // assert
+        assertEq(lResult[0], hex"01");
+        assertEq(lResult[1], bytes1(uint8(aDiff)));
+    }
 }

--- a/test/unit/libraries/FlagsLib.t.sol
+++ b/test/unit/libraries/FlagsLib.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test, console2, stdError } from "forge-std/Test.sol";
+
+import { FlagsLib } from "src/libraries/FlagsLib.sol";
+
+contract FlagsLibTest is Test {
+    using FlagsLib for bytes32;
+    using FlagsLib for int256;
+
+    function testGetDecimalDifference() external {
+        bytes32 lPositive = hex"1f";
+        bytes32 lNegative = hex"3f";
+
+        assertEq(lPositive.getDecimalDifference(), 31);
+        assertEq(lNegative.getDecimalDifference(), -31);
+    }
+
+    function testPackDecimalDifference(int256 aDiff) external {
+        // arrange
+        int256 lDiff = bound(aDiff, -18, 18);
+
+        // act
+        bytes32 lPacked = lDiff.packDecimalDifference();
+
+        // assert
+        assertEq(lDiff, lPacked.getDecimalDifference());
+    }
+
+    function testPackDecimalDifference_BeyondRange() external {
+        // arrange
+        int256 lDiff = -20;
+
+        // act & assert
+        vm.expectRevert(FlagsLib.DECIMAL_DIFF_OUT_OF_RANGE.selector);
+        lDiff.packDecimalDifference();
+    }
+
+    function testCombine() external { }
+}


### PR DESCRIPTION
## Currently 
best case scenario:
- simple route
- num of SLOADs = 4
  - 1 for the existence of route
  - 1 for the length of the route array + first item  
  - 1 for the second item of the array 
  - 1 for the price cache

worst case scenario:
- 3 hop route 
- num of SLOADs = 8 
  - 1 for route query
  - 1 for length of route array + first item 
  - 1 for second item of array
  - 1 for third item of array
  - 1 for fourth item of array 
  - 3 for the price cache for 3 hops  

## Implemented solution
best case scenario:
- simple route
- num of SLOADs = 1 
  - `keccak256` token0-token1 and then loads 1 storage slot
  - reads price from that storage slot

Worst case scenario: 
- 3 hop route 
- num of SLOADs = 6
  - 3 for reading route
  - 3 for reading simple prices 

## Potential Further improvements 

1. we can split some addresses over two words 
   -  i.e. storing 11 bytes in the previous word and then 9 bytes in the next word
   - e.g. 3 hop route (total 63 bytes of data) 
     - instead of reading 3 slots for the route, we only have to read 2 slots 
     - so we save 1 SLOAD
2. Storing the decimal multipliers in the unused bits in the slot
   - if we do this then we won't be able to do improvement no.1

## Alternatives tried 

1. Tried using the following: 

```solidity
mapping(address token0 => mapping(address token1 => bytes wtv))
```

Doesn't work because the the `bytes` will track length. So that's one more SLOAD

2. also tried 

```solidity
mapping(address token0 => mapping(address token1 => bytes wtv))[0:32]
```

doesn't even compile